### PR TITLE
Add GitHub link button to header

### DIFF
--- a/src/components/ui/nav/index.tsx
+++ b/src/components/ui/nav/index.tsx
@@ -23,6 +23,7 @@ import {
 import { Avatar } from "../avatar";
 import { LoginDialog } from "@/feature-login";
 import { CopyURLToClipboard } from "@/feature-share-code";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export const Nav = () => {
   const supabase = createClient();
@@ -151,6 +152,18 @@ export const Nav = () => {
         <ExportMenu />
 
         <CopyURLToClipboard />
+
+        <Tooltip content="GitHub repository">
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={() =>
+              router.push("https://github.com/danarocha-br/jolly-code")
+            }
+          >
+            <i className="ri-github-fill text-xl" />
+          </Button>
+        </Tooltip>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- add a GitHub repository icon button to the header navigation next to the copy link action
- reuse the existing GitHub icon styling with a tooltip pointing to the project repository

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926162362788321a4b06718631ed9a9)