### PR TITLE
Upgrade Sentry Next.js config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,3 @@
-import { withSentryConfig } from "@sentry/nextjs";
-
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -38,32 +35,21 @@ const nextConfig = {
     ];
   },
   turbopack: {},
+  sentry: {
+    dsn:
+      process.env.SENTRY_DSN ||
+      process.env.NEXT_PUBLIC_SENTRY_DSN ||
+      "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
+    tunnelRoute: "/monitoring",
+    hideSourceMaps: true,
+    disableLogger: true,
+    widenClientFileUpload: true,
+    transpileClientSDK: true,
+    sourceMapsUploadOptions: {
+      org: "compasso-9c",
+      project: "jolly-code",
+    },
+  },
 };
 
-export default withSentryConfig(
-  nextConfig,
-  {
-    // For all available options, see:
-    // https://github.com/getsentry/sentry-webpack-plugin#options
-
-    // Suppresses source map uploading logs during build
-    silent: true,
-    org: "compasso-9c",
-    project: "jolly-code",
-  },
-  {
-    // For all available options, see:
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
-
-    widenClientFileUpload: true,
-
-    transpileClientSDK: true,
-
-    // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
-    tunnelRoute: "/monitoring",
-
-    hideSourceMaps: true,
-
-    disableLogger: true,
-  }
-);
+export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@sentry/nextjs": "^7.73.0",
+        "@sentry/nextjs": "^8.0.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.84.0",
         "@tanstack/react-query": "^5.90.10",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@sentry/nextjs": "^7.73.0",
+    "@sentry/nextjs": "^8.0.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.84.0",
     "@tanstack/react-query": "^5.90.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@sentry/nextjs':
-        specifier: ^7.73.0
+        specifier: ^8.0.0
         version: 7.120.4(encoding@0.1.13)(next@16.0.3(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@supabase/ssr':
         specifier: ^0.7.0

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,8 +4,13 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN =
+  process.env.NEXT_PUBLIC_SENTRY_DSN ||
+  process.env.SENTRY_DSN ||
+  "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024";
+
 Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
+  dsn: SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,8 +5,13 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN =
+  process.env.SENTRY_DSN ||
+  process.env.NEXT_PUBLIC_SENTRY_DSN ||
+  "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024";
+
 Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
+  dsn: SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,0 +1,4 @@
+defaults.url=https://sentry.io/
+defaults.org=compasso-9c
+defaults.project=jolly-code
+cli.executable=node_modules/.bin/sentry-cli

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,8 +4,13 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const SENTRY_DSN =
+  process.env.SENTRY_DSN ||
+  process.env.NEXT_PUBLIC_SENTRY_DSN ||
+  "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024";
+
 Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
+  dsn: SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,


### PR DESCRIPTION
## Summary
- bump @sentry/nextjs to the v8 range and update dependency specs in lock files
- replace the Sentry webpack wrapper with the Next.js `sentry` config block using env-driven DSN, tunnel, and source map upload defaults
- align Sentry client, server, and edge configs to read the DSN from environment variables and add `sentry.properties` for CLI defaults

## Testing
- not run (not requested)
- `npx @sentry/wizard@latest -i nextjs` (fails: registry returned HTTP 403 in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927156c8d088321b2b34303fb888783)