### PR TITLE
Refactor Sentry configuration to use shared settings

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,24 +3,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { replaySampleRates, sentrySharedConfig } from "./sentry.config";
 
 Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-
-  // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\/\/jolly-code\.dev\/api/],
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-
-  replaysOnErrorSampleRate: 1.0,
-
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  ...sentrySharedConfig,
+  ...replaySampleRates,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [

--- a/sentry.config.ts
+++ b/sentry.config.ts
@@ -7,7 +7,10 @@ const parseRate = (value: string | undefined, fallback: number) => {
 
 const environment = process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development";
 const tracesSampleRate = parseRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 1);
-const profilesSampleRate = parseRate(process.env.SENTRY_PROFILES_SAMPLE_RATE, tracesSampleRate);
+const profilesSampleRate = parseRate(
+  process.env.SENTRY_PROFILES_SAMPLE_RATE,
+  tracesSampleRate,
+);
 
 const envPropagationTargets = process.env.SENTRY_TRACE_PROPAGATION_TARGETS
   ?.split(",")
@@ -27,8 +30,17 @@ const release =
 const isProduction = environment === "production";
 const isStaging = environment === "staging";
 
-const replaysSessionSampleRate = isProduction ? 0 : isStaging ? 0.2 : 0.1;
-const replaysOnErrorSampleRate = isProduction ? 0.1 : 1.0;
+const replaySessionFallback = isProduction ? 0 : isStaging ? 0.2 : 0.1;
+const replayOnErrorFallback = isProduction ? 0.1 : 1.0;
+
+const replaysSessionSampleRate = parseRate(
+  process.env.SENTRY_REPLAYS_SESSION_SAMPLE_RATE,
+  replaySessionFallback,
+);
+const replaysOnErrorSampleRate = parseRate(
+  process.env.SENTRY_REPLAYS_ON_ERROR_SAMPLE_RATE,
+  replayOnErrorFallback,
+);
 
 export const sentrySharedConfig: Options = {
   dsn: process.env.SENTRY_DSN,
@@ -37,6 +49,8 @@ export const sentrySharedConfig: Options = {
   tracesSampleRate,
   profilesSampleRate,
   tracePropagationTargets,
+  tunnel: process.env.NEXT_PUBLIC_SENTRY_TUNNEL,
+  enabled: Boolean(process.env.SENTRY_DSN),
   debug: false,
 };
 

--- a/sentry.config.ts
+++ b/sentry.config.ts
@@ -1,0 +1,46 @@
+import type { Options } from "@sentry/nextjs";
+
+const parseRate = (value: string | undefined, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const environment = process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || "development";
+const tracesSampleRate = parseRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 1);
+const profilesSampleRate = parseRate(process.env.SENTRY_PROFILES_SAMPLE_RATE, tracesSampleRate);
+
+const envPropagationTargets = process.env.SENTRY_TRACE_PROPAGATION_TARGETS
+  ?.split(",")
+  .map((target) => target.trim())
+  .filter(Boolean);
+
+const tracePropagationTargets =
+  envPropagationTargets && envPropagationTargets.length > 0
+    ? envPropagationTargets
+    : ["localhost", /^https:\/\/jolly-code\.dev\/api/];
+
+const release =
+  process.env.SENTRY_RELEASE ||
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
+const isProduction = environment === "production";
+const isStaging = environment === "staging";
+
+const replaysSessionSampleRate = isProduction ? 0 : isStaging ? 0.2 : 0.1;
+const replaysOnErrorSampleRate = isProduction ? 0.1 : 1.0;
+
+export const sentrySharedConfig: Options = {
+  dsn: process.env.SENTRY_DSN,
+  environment,
+  release,
+  tracesSampleRate,
+  profilesSampleRate,
+  tracePropagationTargets,
+  debug: false,
+};
+
+export const replaySampleRates = {
+  replaysSessionSampleRate,
+  replaysOnErrorSampleRate,
+};

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,13 +4,6 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentrySharedConfig } from "./sentry.config";
 
-Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+Sentry.init(sentrySharedConfig);

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,13 +3,6 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentrySharedConfig } from "./sentry.config";
 
-Sentry.init({
-  dsn: "https://0060b2873d00231ea23837f583d4d017@o4505998703984640.ingest.sentry.io/4505998710145024",
-
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+Sentry.init(sentrySharedConfig);


### PR DESCRIPTION
## Summary
- add shared Sentry configuration sourced from environment variables for DSN, environment, release, tracing, and propagation targets
- update client, server, and edge Sentry initializers to reuse shared options and include profiles sampling
- gate replay sampling rates by environment to reduce production volume while keeping higher sampling in staging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692718c9bee4832199fe14c4b4415441)