### PR TITLE
Improve Sentry instrumentation for routes

### DIFF
--- a/src/app/api/changelog/route.ts
+++ b/src/app/api/changelog/route.ts
@@ -1,38 +1,41 @@
 import { applyRequestContextToSentry, applyResponseContextToSentry } from "@/lib/sentry-context";
 import { wrapRouteHandlerWithSentry } from "@sentry/nextjs";
-import { NextApiResponse } from "next";
 import { NextRequest, NextResponse } from "next/server";
 
-export const POST = wrapRouteHandlerWithSentry(async function POST(
-  req: NextRequest | Request,
-) {
-  if (req instanceof NextRequest) {
-    applyRequestContextToSentry({ request: req });
-  }
+export const POST = wrapRouteHandlerWithSentry(
+  async function POST(req: NextRequest | Request) {
+    if (req instanceof NextRequest) {
+      applyRequestContextToSentry({ request: req });
+    }
 
-  try {
-    const response = await fetch("https://canny.io/api/v1/entries/list", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        apiKey: process.env.NEXT_PUBLIC_CANNY_API_KEY,
-      }),
-    });
-    const result = await response.json();
+    try {
+      const response = await fetch("https://canny.io/api/v1/entries/list", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          apiKey: process.env.NEXT_PUBLIC_CANNY_API_KEY,
+        }),
+      });
+      const result = await response.json();
 
-    applyResponseContextToSentry(200);
+      applyResponseContextToSentry(200);
 
-    return NextResponse.json({
-      status: 200,
-      result,
-    });
-  } catch (error) {
-    applyResponseContextToSentry(500);
-    return NextResponse.json(
-      { error: "An error occurred during the fetch operation." },
-      { status: 500 }
-    );
-  }
-});
+      return NextResponse.json({
+        status: 200,
+        result,
+      });
+    } catch (error) {
+      applyResponseContextToSentry(500);
+      return NextResponse.json(
+        { error: "An error occurred during the fetch operation." },
+        { status: 500 }
+      );
+    }
+  },
+  {
+    method: "POST",
+    parameterizedRoute: "/api/changelog",
+  },
+);

--- a/src/app/api/changelog/route.ts
+++ b/src/app/api/changelog/route.ts
@@ -1,7 +1,15 @@
+import { applyRequestContextToSentry, applyResponseContextToSentry } from "@/lib/sentry-context";
+import { wrapRouteHandlerWithSentry } from "@sentry/nextjs";
 import { NextApiResponse } from "next";
 import { NextRequest, NextResponse } from "next/server";
 
-export async function POST(req: NextRequest | Request) {
+export const POST = wrapRouteHandlerWithSentry(async function POST(
+  req: NextRequest | Request,
+) {
+  if (req instanceof NextRequest) {
+    applyRequestContextToSentry({ request: req });
+  }
+
   try {
     const response = await fetch("https://canny.io/api/v1/entries/list", {
       method: "POST",
@@ -14,14 +22,17 @@ export async function POST(req: NextRequest | Request) {
     });
     const result = await response.json();
 
+    applyResponseContextToSentry(200);
+
     return NextResponse.json({
       status: 200,
       result,
     });
   } catch (error) {
+    applyResponseContextToSentry(500);
     return NextResponse.json(
       { error: "An error occurred during the fetch operation." },
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -4,61 +4,67 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { applyRequestContextToSentry, applyResponseContextToSentry } from '@/lib/sentry-context'
 
-export const GET = wrapRouteHandlerWithSentry(async function GET(request: NextRequest) {
-    applyRequestContextToSentry({ request })
+export const GET = wrapRouteHandlerWithSentry(
+    async function GET(request: NextRequest) {
+        applyRequestContextToSentry({ request })
 
-    try {
-        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-        const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+        try {
+            const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+            const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
-        if (!supabaseUrl || !supabaseServiceKey) {
-            console.error('Missing environment variables for keepalive')
+            if (!supabaseUrl || !supabaseServiceKey) {
+                console.error('Missing environment variables for keepalive')
+                applyResponseContextToSentry(500)
+                return NextResponse.json(
+                    { error: 'Server configuration error' },
+                    { status: 500 }
+                )
+            }
+
+            // Initialize Supabase admin client
+            const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+                auth: {
+                    persistSession: false,
+                    autoRefreshToken: false,
+                },
+            })
+
+            // Perform a lightweight update
+            const { data, error } = await supabase
+                .from('_keepalive')
+                .upsert({ id: 1, last_ping: new Date().toISOString() })
+                .select()
+
+            if (error) {
+                console.error('Keepalive Supabase error:', error)
+                applyResponseContextToSentry(500)
+                return NextResponse.json(
+                    { error: 'Failed to ping database', details: error.message },
+                    { status: 500 }
+                )
+            }
+
+            applyResponseContextToSentry(200)
+            return NextResponse.json(
+                {
+                    status: 'ok',
+                    message: 'Database pinged successfully',
+                    timestamp: new Date().toISOString(),
+                    data,
+                },
+                { status: 200 }
+            )
+        } catch (err) {
+            console.error('Unexpected keepalive error:', err)
             applyResponseContextToSentry(500)
             return NextResponse.json(
-                { error: 'Server configuration error' },
+                { error: 'Internal server error' },
                 { status: 500 }
             )
         }
-
-        // Initialize Supabase admin client
-        const supabase = createClient(supabaseUrl, supabaseServiceKey, {
-            auth: {
-                persistSession: false,
-                autoRefreshToken: false,
-            },
-        })
-
-        // Perform a lightweight update
-        const { data, error } = await supabase
-            .from('_keepalive')
-            .upsert({ id: 1, last_ping: new Date().toISOString() })
-            .select()
-
-        if (error) {
-            console.error('Keepalive Supabase error:', error)
-            applyResponseContextToSentry(500)
-            return NextResponse.json(
-                { error: 'Failed to ping database', details: error.message },
-                { status: 500 }
-            )
-        }
-
-        applyResponseContextToSentry(200)
-        return NextResponse.json(
-            {
-                status: 'ok',
-                message: 'Database pinged successfully',
-                timestamp: new Date().toISOString(),
-                data,
-            },
-            { status: 200 }
-        )
-    } catch (err) {
-        console.error('Unexpected keepalive error:', err)
-        applyResponseContextToSentry(500)
-        return NextResponse.json(
-            { error: 'Internal server error' },
-            { status: 500 }
-        )
-    }
-})
+    },
+    {
+        method: "GET",
+        parameterizedRoute: "/api/keepalive",
+    },
+)

--- a/src/app/api/liveblocks-auth/route.ts
+++ b/src/app/api/liveblocks-auth/route.ts
@@ -1,12 +1,18 @@
-import { Liveblocks } from "@liveblocks/node";
+import { applyRequestContextToSentry, applyResponseContextToSentry } from "@/lib/sentry-context";
 import { createClient } from "@/utils/supabase/server";
-import { NextResponse } from "next/server";
+import { Liveblocks } from "@liveblocks/node";
+import { wrapRouteHandlerWithSentry } from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
 
 const API_KEY = process.env.LIVEBLOCKS_SECRET_KEY!;
 
 const liveblocks = new Liveblocks({ secret: API_KEY });
 
-export async function POST(request: Request) {
+export const POST = wrapRouteHandlerWithSentry(async function POST(
+  request: NextRequest,
+) {
+  applyRequestContextToSentry({ request });
+
   const supabase = await createClient();
 
   // Get the session from Supabase
@@ -18,6 +24,13 @@ export async function POST(request: Request) {
     userId = data.session?.user.id;
   }
 
+  applyRequestContextToSentry({
+    request,
+    userId,
+    featureFlags: data?.session?.user?.user_metadata?.feature_flags,
+    locale: data?.session?.user?.user_metadata?.locale,
+  });
+
   const session = liveblocks.prepareSession(userId, {
     userInfo: data?.session?.user?.user_metadata || {},
   });
@@ -28,8 +41,10 @@ export async function POST(request: Request) {
   // Authorize the user and return the result
   try {
     const { status, body } = await session.authorize();
+    applyResponseContextToSentry(status);
     return new NextResponse(body, { status });
   } catch (e) {
     console.error("Error authorizing session:", e);
+    applyResponseContextToSentry(500);
   }
-}
+});

--- a/src/app/api/liveblocks-auth/route.ts
+++ b/src/app/api/liveblocks-auth/route.ts
@@ -8,43 +8,47 @@ const API_KEY = process.env.LIVEBLOCKS_SECRET_KEY!;
 
 const liveblocks = new Liveblocks({ secret: API_KEY });
 
-export const POST = wrapRouteHandlerWithSentry(async function POST(
-  request: NextRequest,
-) {
-  applyRequestContextToSentry({ request });
+export const POST = wrapRouteHandlerWithSentry(
+  async function POST(request: NextRequest) {
+    applyRequestContextToSentry({ request });
 
-  const supabase = await createClient();
+    const supabase = await createClient();
 
-  // Get the session from Supabase
+    // Get the session from Supabase
 
-  const { data } = await supabase.auth.getSession();
+    const { data } = await supabase.auth.getSession();
 
-  let userId = "anonymous";
-  if (data && data.session?.user?.id) {
-    userId = data.session?.user.id;
-  }
+    let userId = "anonymous";
+    if (data && data.session?.user?.id) {
+      userId = data.session?.user.id;
+    }
 
-  applyRequestContextToSentry({
-    request,
-    userId,
-    featureFlags: data?.session?.user?.user_metadata?.feature_flags,
-    locale: data?.session?.user?.user_metadata?.locale,
-  });
+    applyRequestContextToSentry({
+      request,
+      userId,
+      featureFlags: data?.session?.user?.user_metadata?.feature_flags,
+      locale: data?.session?.user?.user_metadata?.locale,
+    });
 
-  const session = liveblocks.prepareSession(userId, {
-    userInfo: data?.session?.user?.user_metadata || {},
-  });
+    const session = liveblocks.prepareSession(userId, {
+      userInfo: data?.session?.user?.user_metadata || {},
+    });
 
-  const { room } = await request.json();
-  if (room) session.allow(room, session.FULL_ACCESS);
+    const { room } = await request.json();
+    if (room) session.allow(room, session.FULL_ACCESS);
 
-  // Authorize the user and return the result
-  try {
-    const { status, body } = await session.authorize();
-    applyResponseContextToSentry(status);
-    return new NextResponse(body, { status });
-  } catch (e) {
-    console.error("Error authorizing session:", e);
-    applyResponseContextToSentry(500);
-  }
-});
+    // Authorize the user and return the result
+    try {
+      const { status, body } = await session.authorize();
+      applyResponseContextToSentry(status);
+      return new NextResponse(body, { status });
+    } catch (e) {
+      console.error("Error authorizing session:", e);
+      applyResponseContextToSentry(500);
+    }
+  },
+  {
+    method: "POST",
+    parameterizedRoute: "/api/liveblocks-auth",
+  },
+);

--- a/src/app/api/save-shared-url-visits/route.ts
+++ b/src/app/api/save-shared-url-visits/route.ts
@@ -15,69 +15,73 @@ const supabase: SupabaseClient = createClient<Database>(
  * @param {NextRequest} request - The incoming request object.
  * @return {Promise<NextResponse>} - A promise that resolves to the response object.
  */
-export const POST = wrapRouteHandlerWithSentry(async function POST(
-  request: NextRequest,
-) {
-  applyRequestContextToSentry({ request });
+export const POST = wrapRouteHandlerWithSentry(
+  async function POST(request: NextRequest) {
+    applyRequestContextToSentry({ request });
 
-  try {
-    const { id } = await await validateContentType(request).json();
+    try {
+      const { id } = await await validateContentType(request).json();
 
-    if (!id) {
-      applyResponseContextToSentry(400);
-      return NextResponse.json(
-        { message: "No link found in the database." },
-        { status: 400 }
-      );
-    }
+      if (!id) {
+        applyResponseContextToSentry(400);
+        return NextResponse.json(
+          { message: "No link found in the database." },
+          { status: 400 }
+        );
+      }
 
-    const getVisitsResult = await supabase
-      .from("links")
-      .select("visits")
-      .eq("id", id);
+      const getVisitsResult = await supabase
+        .from("links")
+        .select("visits")
+        .eq("id", id);
 
-    if (
-      getVisitsResult.error ||
-      !getVisitsResult.data ||
-      !getVisitsResult.data[0]
-    ) {
-      console.error(getVisitsResult.error);
+      if (
+        getVisitsResult.error ||
+        !getVisitsResult.data ||
+        !getVisitsResult.data[0]
+      ) {
+        console.error(getVisitsResult.error);
+        applyResponseContextToSentry(500);
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      let currentVisits = getVisitsResult.data[0].visits;
+
+      if (currentVisits === null) {
+        currentVisits = 0;
+      }
+
+      const updatedVisitCount = currentVisits + 1;
+
+      let data;
+
+      const result = await supabase
+        .from("links")
+        .update({ visits: updatedVisitCount })
+        .eq("id", id)
+        .select("visits");
+
+      if (result.error) {
+        console.error(result.error);
+        applyResponseContextToSentry(500);
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      data = result.data;
+
+      applyResponseContextToSentry(200);
+
+      return NextResponse.json({
+        status: 200,
+        visits: data[0].visits,
+      });
+    } catch (error) {
       applyResponseContextToSentry(500);
-      return NextResponse.json({ error: "Database error" }, { status: 500 });
+      return NextResponse.json(error, { status: 500 });
     }
-
-    let currentVisits = getVisitsResult.data[0].visits;
-
-    if (currentVisits === null) {
-      currentVisits = 0;
-    }
-
-    const updatedVisitCount = currentVisits + 1;
-
-    let data;
-
-    const result = await supabase
-      .from("links")
-      .update({ visits: updatedVisitCount })
-      .eq("id", id)
-      .select("visits");
-
-    if (result.error) {
-      console.error(result.error);
-      applyResponseContextToSentry(500);
-      return NextResponse.json({ error: "Database error" }, { status: 500 });
-    }
-
-    data = result.data;
-
-    applyResponseContextToSentry(200);
-
-    return NextResponse.json({
-      status: 200,
-      visits: data[0].visits,
-    });
-  } catch (error) {
-    applyResponseContextToSentry(500);
-    return NextResponse.json(error, { status: 500 });
-  }
-});
+  },
+  {
+    method: "POST",
+    parameterizedRoute: "/api/save-shared-url-visits",
+  },
+);

--- a/src/app/api/shorten-url/route.ts
+++ b/src/app/api/shorten-url/route.ts
@@ -1,11 +1,14 @@
-import { NextRequest, NextResponse } from "next/server";
-import { nanoid } from "nanoid";
-
-import { createClient } from "@/utils/supabase/server";
-
+import {
+  applyRequestContextToSentry,
+  applyResponseContextToSentry,
+} from "@/lib/sentry-context";
 import { isValidURL } from "@/lib/utils/is-valid-url";
 import { validateContentType } from "@/lib/utils/validate-content-type-request";
 import { Database } from "@/types/database";
+import { createClient } from "@/utils/supabase/server";
+import { wrapRouteHandlerWithSentry } from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { nanoid } from "nanoid";
 
 export const runtime = "edge";
 
@@ -20,13 +23,17 @@ const keySet: Set<string> = new Set();
  * @param {NextRequest} request - an url
  * @return {Promise<NextResponse>} A promise that resolves to a NextResponse object containing the URL associated with the slug, or an error response if the slug is invalid or not found.
  */
-export async function GET(request: NextRequest) {
+export const GET = wrapRouteHandlerWithSentry(async function GET(
+  request: NextRequest,
+) {
+  applyRequestContextToSentry({ request });
   const supabase = await createClient();
   const url = new URL(request.url);
 
   const slug = url.searchParams.get("slug");
 
   if (!slug) {
+    applyResponseContextToSentry(400);
     return NextResponse.json(
       { error: "No slug was provided." },
       { status: 400 }
@@ -34,6 +41,7 @@ export async function GET(request: NextRequest) {
   }
 
   if (!isValidURL(slug)) {
+    applyResponseContextToSentry(400);
     return NextResponse.json({ error: "Invalid slug." }, { status: 400 });
   }
 
@@ -53,26 +61,34 @@ export async function GET(request: NextRequest) {
   }
 
   if (!data) {
+    applyResponseContextToSentry(404);
     return NextResponse.json({ error: "URL not found." }, { status: 404 });
   }
 
+  applyResponseContextToSentry(200);
   return NextResponse.json({
     status: 200,
     id: data[0].id,
     url: data[0].url,
   });
-}
+});
 
-export async function POST(request: NextRequest) {
+export const POST = wrapRouteHandlerWithSentry(async function POST(
+  request: NextRequest,
+) {
+  applyRequestContextToSentry({ request });
   const supabase = await createClient();
   try {
     const contentType = await request.headers.get("content-type");
     if (contentType !== "application/json") {
+      applyResponseContextToSentry(415);
       return NextResponse.json({ error: "Invalid request" }, { status: 415 });
     }
 
     const { url, snippet_id, user_id } =
       await validateContentType(request).json();
+
+    applyRequestContextToSentry({ request, userId: user_id });
 
     const longUrl = url ? url : null;
     const validURL = await isValidURL(longUrl);
@@ -80,6 +96,7 @@ export async function POST(request: NextRequest) {
     let data;
 
     if (!validURL) {
+      applyResponseContextToSentry(400);
       return NextResponse.json(
         { message: `${longUrl} is not a valid url.` },
         { status: 400 }
@@ -93,11 +110,13 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       console.error(error);
+      applyResponseContextToSentry(500);
       return NextResponse.json({ error: "Database error" }, { status: 500 });
     }
 
     if (existingUrl && existingUrl.length > 0) {
       // URL already exists, return the existing short URL
+      applyResponseContextToSentry(200);
       return NextResponse.json({
         status: 200,
         short_url: existingUrl[0].short_url,
@@ -106,6 +125,7 @@ export async function POST(request: NextRequest) {
 
     const key = nanoid(5);
     if (keySet.has(key)) {
+      applyResponseContextToSentry(400);
       return NextResponse.json(
         { error: "Key is duplicated." },
         { status: 400 }
@@ -130,15 +150,18 @@ export async function POST(request: NextRequest) {
 
     if (insertError) {
       console.error("Insert Error:", insertError);
+      applyResponseContextToSentry(500);
       return NextResponse.json({ error: insertError.message }, { status: 500 });
     }
 
+    applyResponseContextToSentry(200);
     return NextResponse.json({
       status: 200,
       short_url: shortUrl,
     });
   } catch (error: any) {
     console.error("Shorten URL Error:", error);
+    applyResponseContextToSentry(500);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-}
+});

--- a/src/app/api/shorten-url/route.ts
+++ b/src/app/api/shorten-url/route.ts
@@ -23,145 +23,153 @@ const keySet: Set<string> = new Set();
  * @param {NextRequest} request - an url
  * @return {Promise<NextResponse>} A promise that resolves to a NextResponse object containing the URL associated with the slug, or an error response if the slug is invalid or not found.
  */
-export const GET = wrapRouteHandlerWithSentry(async function GET(
-  request: NextRequest,
-) {
-  applyRequestContextToSentry({ request });
-  const supabase = await createClient();
-  const url = new URL(request.url);
+export const GET = wrapRouteHandlerWithSentry(
+  async function GET(request: NextRequest) {
+    applyRequestContextToSentry({ request });
+    const supabase = await createClient();
+    const url = new URL(request.url);
 
-  const slug = url.searchParams.get("slug");
+    const slug = url.searchParams.get("slug");
 
-  if (!slug) {
-    applyResponseContextToSentry(400);
-    return NextResponse.json(
-      { error: "No slug was provided." },
-      { status: 400 }
-    );
-  }
-
-  if (!isValidURL(slug)) {
-    applyResponseContextToSentry(400);
-    return NextResponse.json({ error: "Invalid slug." }, { status: 400 });
-  }
-
-  let data;
-  let error;
-  try {
-    const result = await supabase
-      .from("links")
-      .select("id, url")
-      .eq("short_url", slug);
-
-    data = result.data;
-
-    error = result.error;
-  } catch (error: Error | any) {
-    error = error.message;
-  }
-
-  if (!data) {
-    applyResponseContextToSentry(404);
-    return NextResponse.json({ error: "URL not found." }, { status: 404 });
-  }
-
-  applyResponseContextToSentry(200);
-  return NextResponse.json({
-    status: 200,
-    id: data[0].id,
-    url: data[0].url,
-  });
-});
-
-export const POST = wrapRouteHandlerWithSentry(async function POST(
-  request: NextRequest,
-) {
-  applyRequestContextToSentry({ request });
-  const supabase = await createClient();
-  try {
-    const contentType = await request.headers.get("content-type");
-    if (contentType !== "application/json") {
-      applyResponseContextToSentry(415);
-      return NextResponse.json({ error: "Invalid request" }, { status: 415 });
+    if (!slug) {
+      applyResponseContextToSentry(400);
+      return NextResponse.json(
+        { error: "No slug was provided." },
+        { status: 400 }
+      );
     }
 
-    const { url, snippet_id, user_id } =
-      await validateContentType(request).json();
-
-    applyRequestContextToSentry({ request, userId: user_id });
-
-    const longUrl = url ? url : null;
-    const validURL = await isValidURL(longUrl);
+    if (!isValidURL(slug)) {
+      applyResponseContextToSentry(400);
+      return NextResponse.json({ error: "Invalid slug." }, { status: 400 });
+    }
 
     let data;
+    let error;
+    try {
+      const result = await supabase
+        .from("links")
+        .select("id, url")
+        .eq("short_url", slug);
 
-    if (!validURL) {
-      applyResponseContextToSentry(400);
-      return NextResponse.json(
-        { message: `${longUrl} is not a valid url.` },
-        { status: 400 }
-      );
+      data = result.data;
+
+      error = result.error;
+    } catch (error: Error | any) {
+      error = error.message;
     }
 
-    const { data: existingUrl, error } = await supabase
-      .from("links")
-      .select("url, short_url")
-      .eq("url", longUrl);
-
-    if (error) {
-      console.error(error);
-      applyResponseContextToSentry(500);
-      return NextResponse.json({ error: "Database error" }, { status: 500 });
-    }
-
-    if (existingUrl && existingUrl.length > 0) {
-      // URL already exists, return the existing short URL
-      applyResponseContextToSentry(200);
-      return NextResponse.json({
-        status: 200,
-        short_url: existingUrl[0].short_url,
-      });
-    }
-
-    const key = nanoid(5);
-    if (keySet.has(key)) {
-      applyResponseContextToSentry(400);
-      return NextResponse.json(
-        { error: "Key is duplicated." },
-        { status: 400 }
-      );
-    }
-
-    keySet.add(key);
-    shortURLs[key] = longUrl;
-
-    const shortUrl = key;
-
-    const { error: insertError } = await supabase
-      .from("links")
-      .insert([
-        {
-          user_id: user_id ? user_id : null,
-          url: longUrl,
-          short_url: shortUrl,
-          snippet_id: snippet_id ? snippet_id : null,
-        },
-      ]);
-
-    if (insertError) {
-      console.error("Insert Error:", insertError);
-      applyResponseContextToSentry(500);
-      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    if (!data) {
+      applyResponseContextToSentry(404);
+      return NextResponse.json({ error: "URL not found." }, { status: 404 });
     }
 
     applyResponseContextToSentry(200);
     return NextResponse.json({
       status: 200,
-      short_url: shortUrl,
+      id: data[0].id,
+      url: data[0].url,
     });
-  } catch (error: any) {
-    console.error("Shorten URL Error:", error);
-    applyResponseContextToSentry(500);
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-});
+  },
+  {
+    method: "GET",
+    parameterizedRoute: "/api/shorten-url",
+  },
+);
+
+export const POST = wrapRouteHandlerWithSentry(
+  async function POST(request: NextRequest) {
+    applyRequestContextToSentry({ request });
+    const supabase = await createClient();
+    try {
+      const contentType = await request.headers.get("content-type");
+      if (contentType !== "application/json") {
+        applyResponseContextToSentry(415);
+        return NextResponse.json({ error: "Invalid request" }, { status: 415 });
+      }
+
+      const { url, snippet_id, user_id } =
+        await validateContentType(request).json();
+
+      applyRequestContextToSentry({ request, userId: user_id });
+
+      const longUrl = url ? url : null;
+      const validURL = await isValidURL(longUrl);
+
+      let data;
+
+      if (!validURL) {
+        applyResponseContextToSentry(400);
+        return NextResponse.json(
+          { message: `${longUrl} is not a valid url.` },
+          { status: 400 }
+        );
+      }
+
+      const { data: existingUrl, error } = await supabase
+        .from("links")
+        .select("url, short_url")
+        .eq("url", longUrl);
+
+      if (error) {
+        console.error(error);
+        applyResponseContextToSentry(500);
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+      }
+
+      if (existingUrl && existingUrl.length > 0) {
+        // URL already exists, return the existing short URL
+        applyResponseContextToSentry(200);
+        return NextResponse.json({
+          status: 200,
+          short_url: existingUrl[0].short_url,
+        });
+      }
+
+      const key = nanoid(5);
+      if (keySet.has(key)) {
+        applyResponseContextToSentry(400);
+        return NextResponse.json(
+          { error: "Key is duplicated." },
+          { status: 400 }
+        );
+      }
+
+      keySet.add(key);
+      shortURLs[key] = longUrl;
+
+      const shortUrl = key;
+
+      const { error: insertError } = await supabase
+        .from("links")
+        .insert([
+          {
+            user_id: user_id ? user_id : null,
+            url: longUrl,
+            short_url: shortUrl,
+            snippet_id: snippet_id ? snippet_id : null,
+          },
+        ]);
+
+      if (insertError) {
+        console.error("Insert Error:", insertError);
+        applyResponseContextToSentry(500);
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
+      }
+
+      applyResponseContextToSentry(200);
+      return NextResponse.json({
+        status: 200,
+        short_url: shortUrl,
+      });
+    } catch (error: any) {
+      console.error("Shorten URL Error:", error);
+      applyResponseContextToSentry(500);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  },
+  {
+    method: "POST",
+    parameterizedRoute: "/api/shorten-url",
+  },
+);

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
-import { useEffect } from "react";
 
 export default function GlobalError({
   error,
 }: {
   error: Error & { digest?: string };
 }) {
-  useEffect(() => {
-    Sentry.captureException(error);
-  }, [error]);
-
   return (
     <html>
       <body>
-        <NextError statusCode={undefined as any} />
+        <NextError statusCode={500} title={error.message} />
       </body>
     </html>
   );

--- a/src/lib/sentry-context.ts
+++ b/src/lib/sentry-context.ts
@@ -1,0 +1,52 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest } from "next/server";
+
+type ContextOptions = {
+  request: NextRequest;
+  userId?: string | null;
+  locale?: string | null;
+  featureFlags?: string[] | null;
+};
+
+export function applyRequestContextToSentry({
+  request,
+  userId,
+  locale,
+  featureFlags,
+}: ContextOptions) {
+  const url = new URL(request.url);
+
+  Sentry.setTag("request.method", request.method);
+  Sentry.setTag("request.path", url.pathname);
+
+  const resolvedLocale =
+    locale ?? request.headers.get("accept-language")?.split(",")[0];
+  if (resolvedLocale) {
+    Sentry.setTag("locale", resolvedLocale);
+  }
+
+  if (userId) {
+    Sentry.setUser({ id: userId });
+  }
+
+  const resolvedFeatureFlags =
+    featureFlags ?? parseFeatureFlagHeader(request.headers.get("x-feature-flags"));
+  if (resolvedFeatureFlags.length > 0) {
+    Sentry.setContext("feature_flags", { flags: resolvedFeatureFlags });
+  }
+}
+
+export function applyResponseContextToSentry(status: number) {
+  Sentry.setTag("response.status_code", status.toString());
+}
+
+function parseFeatureFlagHeader(headerValue: string | null) {
+  if (!headerValue) {
+    return [] as string[];
+  }
+
+  return headerValue
+    .split(",")
+    .map((flag) => flag.trim())
+    .filter(Boolean);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,12 @@
-import { type NextRequest } from 'next/server'
 import { updateSession } from '@/utils/supabase/middleware'
+import { wrapMiddlewareWithSentry } from '@sentry/nextjs'
+import { type NextRequest } from 'next/server'
 
-export async function middleware(request: NextRequest) {
+export const middleware = wrapMiddlewareWithSentry(async function middleware(
+  request: NextRequest,
+) {
   return await updateSession(request)
-}
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- rely on the SDK's automatic error capture by simplifying the global app error boundary
- add a shared helper for tagging Sentry events with request context and wrap app routes/middleware with Sentry instrumentation
- record response status, locale, feature flag, and user context across API route handlers

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271985c0a88321aa570d2603636305)